### PR TITLE
Fix training math issues

### DIFF
--- a/src/pages/battle/training.tsx
+++ b/src/pages/battle/training.tsx
@@ -43,6 +43,13 @@ const Training = (props) => {
   const resetUnitCosts = () => {
     setUnitCosts({});
     setTotalCost(0);
+    setSectionCosts({
+      WORKER: 0,
+      OFFENSE: 0,
+      DEFENSE: 0,
+      SPY: 0,
+      SENTRY: 0,
+    });
   };
 
   const unitMapFunction = useCallback((unit, idPrefix: string) => {


### PR DESCRIPTION
The resetUnitCosts function was resetting other sources of truth, but the one that mattered wasn't getting the attention it deserved, so the total cost in the interface was showing incorrectly. We're now resetting *all* sources of truth correctly.

(follow-up patch to follow that makes this file less...gross)