### PR TITLE
Fix the defense stats not updating correctly

### DIFF
--- a/src/app/actions.tsx
+++ b/src/app/actions.tsx
@@ -72,7 +72,6 @@ export async function spyHandler(attackerId: number, defenderId: number, spies: 
   await incrementUserStats(attackerId, {
     type: 'SPY',
     subtype: (attackerId === Winner.id) ? 'WON' : 'LOST',
-    stat: 1
   });
   await incrementUserStats(defenderId, {
     type: 'SENTRY',
@@ -194,7 +193,6 @@ export async function attackHandler(
       await incrementUserStats(attackerId, {
         type: 'OFFENSE',
         subtype: (isAttackerWinner) ? 'WON' : 'LOST',
-        stat: 1
       });
 
       await incrementUserStats(defenderId, {

--- a/src/services/attack.service.ts
+++ b/src/services/attack.service.ts
@@ -36,6 +36,7 @@ export const createAttackLog = async (logData) => {
 
 // { type: 'OFFENSE', subtype: 'TOTAL', stat: 1 } +1
 // { type: 'OFFENSE', subtype: 'WON', stat: 12 } +12
+// { type: 'DEFENSE', subtype: 'LOST' } +1 (defaults to 1 if not specified)
 export const incrementUserStats = async (userId, newStat) => {
   const user = await prisma.users.findUnique({
     where: { id: userId },
@@ -64,7 +65,7 @@ export const incrementUserStats = async (userId, newStat) => {
     user.stats.push({
       type: newStat.type,
       subtype: newStat.subtype,
-      stat: newStat.stat
+      stat: newStat.stat || 1,
     });
   }
 


### PR DESCRIPTION
Also made it so incrementUserStats has a sane default (increment by 1), so if we forget to include the stat in the future, we won't miss data (like we have done until now!)

Fixes #182