### PR TITLE
Fix "attack again" modal on war history pages

### DIFF
--- a/src/components/attackResult.tsx
+++ b/src/components/attackResult.tsx
@@ -5,7 +5,6 @@ import { Grid, Space, Group, Button, Text, Paper } from "@mantine/core";
 import { AnimatePresence, motion } from "framer-motion";
 import Image from "next/image";
 import Modal from "./modal";
-import users from "@/pages/battle/users";
 import { useState } from "react";
 
 const attackResults = ({ battle, viewerID }) => {
@@ -125,7 +124,7 @@ const attackResults = ({ battle, viewerID }) => {
               <Modal
                 isOpen={isOpen}
                 toggleModal={toggleModal}
-                profileID={(isViewerAttacker ? users.id : attackerPlayer.id)}
+                profileID={(isViewerAttacker ? defenderPlayer.id : attackerPlayer.id)}
               />
                 </Group>
             


### PR DESCRIPTION
For some reason we were trying to access the id of the entire user list, instead of the defender player? Anyway, this should fix #205.