### PR TITLE
Fix string splitting over multi-word names

### DIFF
--- a/src/pages/api/armory/convert.ts
+++ b/src/pages/api/armory/convert.ts
@@ -39,8 +39,8 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
       return res.status(400).json({ error: 'Invalid conversion amount' });
     }
 
-    const [fromUsage, fromType] = fromItem.split('_');
-    const [toUsage, toType] = toItem.split('_');
+    const [fromUsage, fromType] = fromItem.split(/_(.+)/);
+    const [toUsage, toType] = toItem.split(/_(.+)/);
 
     const toItemType = ItemTypes.find((item) => item.id === toType && item.usage === toUsage );
     const fromItemType = ItemTypes.find((item) => item.id === fromType && item.usage === fromUsage );


### PR DESCRIPTION
e.g. "DEFENSE_PADDED_HOOD".split('_') would result in ["DEFENSE", "PADDED", "HOOD"] - this change uses the `limit` argument to split to ensure we only get two outputs.

I think this is a slightly more elegant fix than 6e926e8da3320ce61d3aaf3bb0e55dd68946b919 but I'm willing to be wrong.